### PR TITLE
fix: don't write an alarming job summary when no `.po` files are found

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -38,6 +38,7 @@
       ],
       "rules": {
         "eslint/init-declarations": "off",
+        "eslint/max-lines": "off",
         "eslint/no-magic-numbers": "off",
         "eslint/sort-keys": "off",
         "eslint/sort-vars": "off",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ If no duplicate `msgid`s are found, the action will succeed and provide a confir
 
 ![Screenshot of a passing run with no duplicate msgids found](readme-assets/no-duplicate-msgids-found.png)
 
+#### When no `.po` files are found
+
+If the repository contains no `.po` files at all, there is nothing to check. The action succeeds and deliberately adds nothing to the job summary, so it doesn't look like something went wrong. It only writes a line to the workflow log:
+
+```
+No .po files found, nothing to check.
+```
+
 ### As a CLI tool
 
 You can also use this tool from your terminal using `npx`. This is useful for local checks.
@@ -68,6 +76,13 @@ $ npx @limetech/po-linter
 Checking file: src/translations/en.po
 Checking file: src/translations/sv.po
 ✅ No duplicate msgids found.
+```
+
+#### When no `.po` files are found
+
+```bash
+$ npx @limetech/po-linter
+No .po files found, nothing to check.
 ```
 
 ## Inputs

--- a/constants.js
+++ b/constants.js
@@ -8,7 +8,12 @@ function escapeHtml(unsafe) {
 }
 
 module.exports = {
+    // The job summary is rendered as one contiguous block of HTML, so Markdown
+    // is not processed within it.
+    ATTRIBUTION:
+        '<sub>Reported by <a href="https://github.com/Lundalogik/po-linter">po-linter</a></sub>',
     EXIT_CODE_FAILURE: 1,
     HEADING_LEVEL_2: 2,
+    NO_FILES_MESSAGE: 'No .po files found, nothing to check.',
     escapeHtml,
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -15,8 +15,13 @@ function escapeHtml(unsafe) {
 }
 
 module.exports = {
+    // The job summary is rendered as one contiguous block of HTML, so Markdown
+    // is not processed within it.
+    ATTRIBUTION:
+        '<sub>Reported by <a href="https://github.com/Lundalogik/po-linter">po-linter</a></sub>',
     EXIT_CODE_FAILURE: 1,
     HEADING_LEVEL_2: 2,
+    NO_FILES_MESSAGE: 'No .po files found, nothing to check.',
     escapeHtml,
 };
 
@@ -28666,14 +28671,14 @@ module.exports = {
 /***/ 7092:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { EXIT_CODE_FAILURE } = __nccwpck_require__(461);
+const { EXIT_CODE_FAILURE, NO_FILES_MESSAGE } = __nccwpck_require__(461);
 class ConsoleReporter {
     reportSuccess() {
         console.log('✅ No duplicate msgids found.');
     }
 
     reportNoFilesFound() {
-        console.log('No .po files found.');
+        console.log(NO_FILES_MESSAGE);
     }
 
     reportFailure(allDuplicates) {
@@ -28709,21 +28714,33 @@ module.exports = ConsoleReporter;
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const core = __nccwpck_require__(7484);
-const { HEADING_LEVEL_2, escapeHtml } = __nccwpck_require__(461);
+const {
+    ATTRIBUTION,
+    HEADING_LEVEL_2,
+    NO_FILES_MESSAGE,
+    escapeHtml,
+} = __nccwpck_require__(461);
+
+function addAttribution(summary) {
+    return summary.addSeparator().addRaw(ATTRIBUTION);
+}
+
 class GitHubActionsReporter {
     async reportSuccess() {
-        await core.summary
-            .addHeading('✅ No Duplicate `msgid`s Found')
+        const summary = core.summary
+            .addHeading('✅ No Duplicate `msgid`s Found', HEADING_LEVEL_2)
             .addRaw(
                 'All `.po` files were checked and no duplicate `msgid`s were found.',
-            )
-            .write();
+            );
+        await addAttribution(summary).write();
         core.info('No duplicate msgids found.');
     }
 
-    async reportNoFilesFound() {
-        core.info('No .po files found.');
-        await core.summary.addHeading('No `.po` files found').write();
+    reportNoFilesFound() {
+        // Deliberately not written to the job summary: having nothing to check
+        // is a non-event, and a summary makes it look like something went
+        // wrong.
+        core.info(NO_FILES_MESSAGE);
     }
 
     async reportFailure(allDuplicates) {
@@ -28750,19 +28767,19 @@ class GitHubActionsReporter {
             );
         }
 
-        await summary.write();
+        await addAttribution(summary).write();
         core.setFailed('Duplicate msgids found in one or more .po files.');
     }
 
     async reportFatalError(error) {
         core.setFailed(error.message);
-        await core.summary
-            .addHeading('❗ Error')
+        const summary = core.summary
+            .addHeading('❗ Error', HEADING_LEVEL_2)
             .addRaw(
                 'An unexpected error occurred while checking for duplicate `msgid`s.',
             )
-            .addCodeBlock(error.stack || error.message, 'javascript')
-            .write();
+            .addCodeBlock(error.stack || error.message, 'javascript');
+        await addAttribution(summary).write();
     }
 
     reportDuplicate(file, msgid) {

--- a/index.spec.js
+++ b/index.spec.js
@@ -69,6 +69,7 @@ describe('po-linter', () => {
                 await linter.reportSuccess();
                 expect(core.summary.addHeading).toHaveBeenCalledWith(
                     '✅ No Duplicate `msgid`s Found',
+                    2,
                 );
                 expect(core.summary.write).toHaveBeenCalled();
                 expect(core.info).toHaveBeenCalledWith(
@@ -76,14 +77,23 @@ describe('po-linter', () => {
                 );
             });
 
-            it('reportNoFilesFound generates a GitHub Actions summary', async () => {
+            it('reportSuccess attributes the summary to po-linter', async () => {
+                const linter = new PoLinter();
+                await linter.reportSuccess();
+                expect(core.summary.addRaw).toHaveBeenCalledWith(
+                    '<sub>Reported by <a href="https://github.com/Lundalogik/po-linter">po-linter</a></sub>',
+                );
+            });
+
+            it('reportNoFilesFound logs without generating a GitHub Actions summary', async () => {
                 const linter = new PoLinter();
                 await linter.reportNoFilesFound();
-                expect(core.info).toHaveBeenCalledWith('No .po files found.');
-                expect(core.summary.addHeading).toHaveBeenCalledWith(
-                    'No `.po` files found',
+                expect(core.info).toHaveBeenCalledWith(
+                    'No .po files found, nothing to check.',
                 );
-                expect(core.summary.write).toHaveBeenCalled();
+                expect(core.summary.addHeading).not.toHaveBeenCalled();
+                expect(core.summary.addRaw).not.toHaveBeenCalled();
+                expect(core.summary.write).not.toHaveBeenCalled();
             });
 
             it('reportFatalError sets failed and generates a GitHub Actions summary', async () => {
@@ -94,12 +104,21 @@ describe('po-linter', () => {
                 expect(core.setFailed).toHaveBeenCalledWith('test error');
                 expect(core.summary.addHeading).toHaveBeenCalledWith(
                     '❗ Error',
+                    2,
                 );
                 expect(core.summary.addCodeBlock).toHaveBeenCalledWith(
                     'stack trace',
                     'javascript',
                 );
                 expect(core.summary.write).toHaveBeenCalled();
+            });
+
+            it('reportFatalError attributes the summary to po-linter', async () => {
+                const linter = new PoLinter();
+                await linter.reportFatalError(new Error('test error'));
+                expect(core.summary.addRaw).toHaveBeenCalledWith(
+                    '<sub>Reported by <a href="https://github.com/Lundalogik/po-linter">po-linter</a></sub>',
+                );
             });
 
             it('reportFailure sets failed and generates a detailed GitHub Actions summary', async () => {
@@ -128,6 +147,15 @@ describe('po-linter', () => {
                 );
                 expect(core.summary.write).toHaveBeenCalled();
             });
+
+            it('reportFailure attributes the summary to po-linter', async () => {
+                const linter = new PoLinter();
+                const duplicates = new Map([['file1.po', new Set(['msgid1'])]]);
+                await linter.reportFailure(duplicates);
+                expect(core.summary.addRaw).toHaveBeenCalledWith(
+                    '<sub>Reported by <a href="https://github.com/Lundalogik/po-linter">po-linter</a></sub>',
+                );
+            });
         });
 
         describe('without GITHUB_ACTIONS', () => {
@@ -146,7 +174,9 @@ describe('po-linter', () => {
             it('reportNoFilesFound logs to console', async () => {
                 const linter = new PoLinter();
                 await linter.reportNoFilesFound();
-                expect(console.log).toHaveBeenCalledWith('No .po files found.');
+                expect(console.log).toHaveBeenCalledWith(
+                    'No .po files found, nothing to check.',
+                );
             });
 
             it('reportFatalError logs to console and exits', async () => {
@@ -197,7 +227,9 @@ describe('po-linter', () => {
             });
 
             await linter.main();
-            expect(core.info).toHaveBeenCalledWith('No .po files found.');
+            expect(core.info).toHaveBeenCalledWith(
+                'No .po files found, nothing to check.',
+            );
         });
 
         it('reports success when no duplicates are found', async () => {

--- a/reporters/console-reporter.js
+++ b/reporters/console-reporter.js
@@ -1,11 +1,11 @@
-const { EXIT_CODE_FAILURE } = require('../constants');
+const { EXIT_CODE_FAILURE, NO_FILES_MESSAGE } = require('../constants');
 class ConsoleReporter {
     reportSuccess() {
         console.log('✅ No duplicate msgids found.');
     }
 
     reportNoFilesFound() {
-        console.log('No .po files found.');
+        console.log(NO_FILES_MESSAGE);
     }
 
     reportFailure(allDuplicates) {

--- a/reporters/github-actions-reporter.js
+++ b/reporters/github-actions-reporter.js
@@ -1,19 +1,31 @@
 const core = require('@actions/core');
-const { HEADING_LEVEL_2, escapeHtml } = require('../constants');
+const {
+    ATTRIBUTION,
+    HEADING_LEVEL_2,
+    NO_FILES_MESSAGE,
+    escapeHtml,
+} = require('../constants');
+
+function addAttribution(summary) {
+    return summary.addSeparator().addRaw(ATTRIBUTION);
+}
+
 class GitHubActionsReporter {
     async reportSuccess() {
-        await core.summary
-            .addHeading('✅ No Duplicate `msgid`s Found')
+        const summary = core.summary
+            .addHeading('✅ No Duplicate `msgid`s Found', HEADING_LEVEL_2)
             .addRaw(
                 'All `.po` files were checked and no duplicate `msgid`s were found.',
-            )
-            .write();
+            );
+        await addAttribution(summary).write();
         core.info('No duplicate msgids found.');
     }
 
-    async reportNoFilesFound() {
-        core.info('No .po files found.');
-        await core.summary.addHeading('No `.po` files found').write();
+    reportNoFilesFound() {
+        // Deliberately not written to the job summary: having nothing to check
+        // is a non-event, and a summary makes it look like something went
+        // wrong.
+        core.info(NO_FILES_MESSAGE);
     }
 
     async reportFailure(allDuplicates) {
@@ -40,19 +52,19 @@ class GitHubActionsReporter {
             );
         }
 
-        await summary.write();
+        await addAttribution(summary).write();
         core.setFailed('Duplicate msgids found in one or more .po files.');
     }
 
     async reportFatalError(error) {
         core.setFailed(error.message);
-        await core.summary
-            .addHeading('❗ Error')
+        const summary = core.summary
+            .addHeading('❗ Error', HEADING_LEVEL_2)
             .addRaw(
                 'An unexpected error occurred while checking for duplicate `msgid`s.',
             )
-            .addCodeBlock(error.stack || error.message, 'javascript')
-            .write();
+            .addCodeBlock(error.stack || error.message, 'javascript');
+        await addAttribution(summary).write();
     }
 
     reportDuplicate(file, msgid) {


### PR DESCRIPTION
Fixes #5.

When a repository has no `.po` files, there is nothing for po-linter to check. That is a non-event, but until now the action announced it with a large, unattributed `No .po files found` heading in the job summary. In a workflow run that failed for some unrelated reason, that heading reads like the cause of the failure.

## What changes

**Nothing is written to the job summary when no `.po` files are found.** The step contributes no summary card at all, so there is nothing left to misread. The fact is still recorded in the workflow log:

```
No .po files found, nothing to check.
```

**The summaries that remain now say who wrote them.** Success, failure and fatal-error summaries get a footer:

> ---
> <sub>Reported by <a href="https://github.com/Lundalogik/po-linter">po-linter</a></sub>

The original issue pointed out that there was nothing telling the reader where the message came from. That applies to every summary this action writes, not only the one being removed, so all three got the footer.

**Heading levels are consistent.** `reportSuccess` and `reportFatalError` used `h1` while `reportFailure` already used `h2`. They are all `h2` now. The oversized `h1` was part of what made the old message shout.

## Verification

Run against a directory with no `.po` files, with `GITHUB_STEP_SUMMARY` pointed at a file:

```
$ GITHUB_ACTIONS=true GITHUB_STEP_SUMMARY=summary.md node dist/index.js
No .po files found, nothing to check.
$ wc -c < summary.md
0
```

`npm run lint`, `npm test` and `npm run build` all pass, and the committed `dist/` matches a fresh build.

## Notes for the reviewer

- The two README screenshots still show the old `h1` success heading and no attribution footer. They need re-capturing at some point; that is not done here.
- `index.spec.js` grew past oxlint's 300-line `max-lines` limit. I added `eslint/max-lines` to the override block that already turns off `max-lines-per-function` for spec files, rather than splitting the spec file and turning this into a diff made mostly of moved lines. Say the word if you would rather have the split.
- While writing this I found that the summary bodies are built as Markdown but rendered as HTML, so backticks show up literally (`` `msgid` `` instead of `msgid`). That is pre-existing and untouched here — it is fixed in the pull request stacked on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
