### PR TITLE
fix: render job summary markup instead of printing it literally

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,5 +1,6 @@
+// Coerces its input, since anything thrown can end up here, not only strings.
 function escapeHtml(unsafe) {
-    return unsafe
+    return String(unsafe)
         .replaceAll('&', '&amp;')
         .replaceAll('<', '&lt;')
         .replaceAll('>', '&gt;')

--- a/dist/index.js
+++ b/dist/index.js
@@ -5,8 +5,9 @@
 /***/ 461:
 /***/ ((module) => {
 
+// Coerces its input, since anything thrown can end up here, not only strings.
 function escapeHtml(unsafe) {
-    return unsafe
+    return String(unsafe)
         .replaceAll('&', '&amp;')
         .replaceAll('<', '&lt;')
         .replaceAll('>', '&gt;')
@@ -28728,9 +28729,12 @@ function addAttribution(summary) {
 class GitHubActionsReporter {
     async reportSuccess() {
         const summary = core.summary
-            .addHeading('✅ No Duplicate `msgid`s Found', HEADING_LEVEL_2)
+            .addHeading(
+                '✅ No Duplicate <code>msgid</code>s Found',
+                HEADING_LEVEL_2,
+            )
             .addRaw(
-                'All `.po` files were checked and no duplicate `msgid`s were found.',
+                'All <code>.po</code> files were checked and no duplicate <code>msgid</code>s were found.',
             );
         await addAttribution(summary).write();
         core.info('No duplicate msgids found.');
@@ -28750,7 +28754,7 @@ class GitHubActionsReporter {
                 HEADING_LEVEL_2,
             )
             .addRaw(
-                `The following files contain duplicate \`msgid\` entries. This can cause issues with translations. Please resolve them.`,
+                'The following files contain duplicate <code>msgid</code> entries. This can cause issues with translations. Please resolve them.',
             )
             .addSeparator();
 
@@ -28762,7 +28766,7 @@ class GitHubActionsReporter {
                 )
                 .join('');
             summary.addDetails(
-                `\`${file}\` (${duplicates.size} duplicates)`,
+                `<code>${escapeHtml(file)}</code> (${duplicates.size} duplicates)`,
                 `<ul>${listItems}</ul>`,
             );
         }
@@ -28772,13 +28776,18 @@ class GitHubActionsReporter {
     }
 
     async reportFatalError(error) {
-        core.setFailed(error.message);
+        // Anything can be thrown, not just an `Error`, so fall back to the
+        // thrown value itself rather than reporting nothing.
+        const message = error?.message || String(error);
+        const details = error?.stack || message;
+
+        core.setFailed(message);
         const summary = core.summary
             .addHeading('❗ Error', HEADING_LEVEL_2)
             .addRaw(
-                'An unexpected error occurred while checking for duplicate `msgid`s.',
+                'An unexpected error occurred while checking for duplicate <code>msgid</code>s.',
             )
-            .addCodeBlock(error.stack || error.message, 'javascript');
+            .addCodeBlock(escapeHtml(details), 'javascript');
         await addAttribution(summary).write();
     }
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -56,6 +56,15 @@ describe('po-linter', () => {
                 '&lt;script&gt;alert(&quot;XSS &amp; Injection &#039;FAIL&#039;&quot;)&lt;/script&gt;';
             expect(escapeHtml(unsafe)).toBe(expected);
         });
+
+        it('coerces input that is not a string', () => {
+            expect(escapeHtml(42)).toBe('42');
+            // `undefined` is the value that actually reaches this function
+            // when a thrown value has no `stack` or `message`, so it is worth
+            // asserting explicitly.
+            // eslint-disable-next-line unicorn/no-useless-undefined
+            expect(escapeHtml(undefined)).toBe('undefined');
+        });
     });
 
     describe('reporters', () => {
@@ -68,8 +77,11 @@ describe('po-linter', () => {
                 const linter = new PoLinter();
                 await linter.reportSuccess();
                 expect(core.summary.addHeading).toHaveBeenCalledWith(
-                    '✅ No Duplicate `msgid`s Found',
+                    '✅ No Duplicate <code>msgid</code>s Found',
                     2,
+                );
+                expect(core.summary.addRaw).toHaveBeenCalledWith(
+                    'All <code>.po</code> files were checked and no duplicate <code>msgid</code>s were found.',
                 );
                 expect(core.summary.write).toHaveBeenCalled();
                 expect(core.info).toHaveBeenCalledWith(
@@ -106,8 +118,46 @@ describe('po-linter', () => {
                     '❗ Error',
                     2,
                 );
+                expect(core.summary.addRaw).toHaveBeenCalledWith(
+                    'An unexpected error occurred while checking for duplicate <code>msgid</code>s.',
+                );
                 expect(core.summary.addCodeBlock).toHaveBeenCalledWith(
                     'stack trace',
+                    'javascript',
+                );
+                expect(core.summary.write).toHaveBeenCalled();
+            });
+
+            it('reportFatalError escapes HTML in the stack trace', async () => {
+                const linter = new PoLinter();
+                const error = new Error('test error');
+                error.stack = 'Error: cannot read <config>';
+                await linter.reportFatalError(error);
+                expect(core.summary.addCodeBlock).toHaveBeenCalledWith(
+                    'Error: cannot read &lt;config&gt;',
+                    'javascript',
+                );
+            });
+
+            it('reportFatalError falls back to the escaped error message', async () => {
+                const linter = new PoLinter();
+                const error = new Error('cannot read <config>');
+                error.stack = undefined;
+                await linter.reportFatalError(error);
+                expect(core.summary.addCodeBlock).toHaveBeenCalledWith(
+                    'cannot read &lt;config&gt;',
+                    'javascript',
+                );
+            });
+
+            it('reportFatalError reports a thrown value that is not an Error', async () => {
+                const linter = new PoLinter();
+                await linter.reportFatalError('boom: a thrown string');
+                expect(core.setFailed).toHaveBeenCalledWith(
+                    'boom: a thrown string',
+                );
+                expect(core.summary.addCodeBlock).toHaveBeenCalledWith(
+                    'boom: a thrown string',
                     'javascript',
                 );
                 expect(core.summary.write).toHaveBeenCalled();
@@ -136,9 +186,12 @@ describe('po-linter', () => {
                     "❌ Found duplicate msgid's in 2 file(s)",
                     2,
                 );
+                expect(core.summary.addRaw).toHaveBeenCalledWith(
+                    'The following files contain duplicate <code>msgid</code> entries. This can cause issues with translations. Please resolve them.',
+                );
                 expect(core.summary.addDetails).toHaveBeenCalledTimes(2);
                 expect(core.summary.addDetails).toHaveBeenCalledWith(
-                    '`file1.po` (2 duplicates)',
+                    '<code>file1.po</code> (2 duplicates)',
                     `<ul><li><pre><code>${escapeHtml(
                         'msgid1',
                     )}</code></pre></li><li><pre><code>${escapeHtml(
@@ -146,6 +199,18 @@ describe('po-linter', () => {
                     )}</code></pre></li></ul>`,
                 );
                 expect(core.summary.write).toHaveBeenCalled();
+            });
+
+            it('reportFailure escapes HTML in file names', async () => {
+                const linter = new PoLinter();
+                const duplicates = new Map([
+                    ['<script>.po', new Set(['msgid1'])],
+                ]);
+                await linter.reportFailure(duplicates);
+                expect(core.summary.addDetails).toHaveBeenCalledWith(
+                    '<code>&lt;script&gt;.po</code> (1 duplicates)',
+                    expect.any(String),
+                );
             });
 
             it('reportFailure attributes the summary to po-linter', async () => {
@@ -284,6 +349,19 @@ describe('po-linter', () => {
             await linter.main();
             expect(console.error).toHaveBeenCalledWith('❗ Error');
             expect(console.error).toHaveBeenCalledWith(error);
+        });
+
+        it('handles a non-Error thrown during glob creation', async () => {
+            process.env.GITHUB_ACTIONS = 'true';
+            const linter = new PoLinter();
+            glob.create.mockRejectedValue('boom: a thrown string');
+
+            await linter.main();
+
+            expect(core.setFailed).toHaveBeenCalledWith(
+                'boom: a thrown string',
+            );
+            expect(core.summary.write).toHaveBeenCalled();
         });
 
         it('handles errors during pofile loading', async () => {

--- a/index.spec.js
+++ b/index.spec.js
@@ -40,6 +40,33 @@ describe('po-linter', () => {
         jest.restoreAllMocks();
     });
 
+    const ATTRIBUTION_HTML =
+        '<sub>Reported by <a href="https://github.com/Lundalogik/po-linter">po-linter</a></sub>';
+
+    // Every `core.summary` method that appends to the summary. `write` is
+    // excluded, since it flushes the buffer rather than adding to it.
+    const SUMMARY_CONTENT_METHODS = [
+        'addHeading',
+        'addRaw',
+        'addSeparator',
+        'addDetails',
+        'addCodeBlock',
+    ];
+
+    // The attribution is a footer, so asserting that it was added is not
+    // enough: it also has to be the last thing added.
+    function expectAttributionAddedLast() {
+        expect(core.summary.addRaw).toHaveBeenLastCalledWith(ATTRIBUTION_HTML);
+
+        const attributionCall =
+            core.summary.addRaw.mock.invocationCallOrder.at(-1);
+        const callsAfterAttribution = SUMMARY_CONTENT_METHODS.flatMap(
+            (method) => core.summary[method].mock.invocationCallOrder,
+        ).filter((call) => call > attributionCall);
+
+        expect(callsAfterAttribution).toEqual([]);
+    }
+
     describe('escapeHtml', () => {
         let escapeHtml;
         beforeEach(() => {
@@ -89,12 +116,10 @@ describe('po-linter', () => {
                 );
             });
 
-            it('reportSuccess attributes the summary to po-linter', async () => {
+            it('reportSuccess adds the po-linter attribution last', async () => {
                 const linter = new PoLinter();
                 await linter.reportSuccess();
-                expect(core.summary.addRaw).toHaveBeenCalledWith(
-                    '<sub>Reported by <a href="https://github.com/Lundalogik/po-linter">po-linter</a></sub>',
-                );
+                expectAttributionAddedLast();
             });
 
             it('reportNoFilesFound logs without generating a GitHub Actions summary', async () => {
@@ -163,12 +188,10 @@ describe('po-linter', () => {
                 expect(core.summary.write).toHaveBeenCalled();
             });
 
-            it('reportFatalError attributes the summary to po-linter', async () => {
+            it('reportFatalError adds the po-linter attribution last', async () => {
                 const linter = new PoLinter();
                 await linter.reportFatalError(new Error('test error'));
-                expect(core.summary.addRaw).toHaveBeenCalledWith(
-                    '<sub>Reported by <a href="https://github.com/Lundalogik/po-linter">po-linter</a></sub>',
-                );
+                expectAttributionAddedLast();
             });
 
             it('reportFailure sets failed and generates a detailed GitHub Actions summary', async () => {
@@ -213,13 +236,11 @@ describe('po-linter', () => {
                 );
             });
 
-            it('reportFailure attributes the summary to po-linter', async () => {
+            it('reportFailure adds the po-linter attribution last', async () => {
                 const linter = new PoLinter();
                 const duplicates = new Map([['file1.po', new Set(['msgid1'])]]);
                 await linter.reportFailure(duplicates);
-                expect(core.summary.addRaw).toHaveBeenCalledWith(
-                    '<sub>Reported by <a href="https://github.com/Lundalogik/po-linter">po-linter</a></sub>',
-                );
+                expectAttributionAddedLast();
             });
         });
 

--- a/reporters/github-actions-reporter.js
+++ b/reporters/github-actions-reporter.js
@@ -13,9 +13,12 @@ function addAttribution(summary) {
 class GitHubActionsReporter {
     async reportSuccess() {
         const summary = core.summary
-            .addHeading('✅ No Duplicate `msgid`s Found', HEADING_LEVEL_2)
+            .addHeading(
+                '✅ No Duplicate <code>msgid</code>s Found',
+                HEADING_LEVEL_2,
+            )
             .addRaw(
-                'All `.po` files were checked and no duplicate `msgid`s were found.',
+                'All <code>.po</code> files were checked and no duplicate <code>msgid</code>s were found.',
             );
         await addAttribution(summary).write();
         core.info('No duplicate msgids found.');
@@ -35,7 +38,7 @@ class GitHubActionsReporter {
                 HEADING_LEVEL_2,
             )
             .addRaw(
-                `The following files contain duplicate \`msgid\` entries. This can cause issues with translations. Please resolve them.`,
+                'The following files contain duplicate <code>msgid</code> entries. This can cause issues with translations. Please resolve them.',
             )
             .addSeparator();
 
@@ -47,7 +50,7 @@ class GitHubActionsReporter {
                 )
                 .join('');
             summary.addDetails(
-                `\`${file}\` (${duplicates.size} duplicates)`,
+                `<code>${escapeHtml(file)}</code> (${duplicates.size} duplicates)`,
                 `<ul>${listItems}</ul>`,
             );
         }
@@ -57,13 +60,18 @@ class GitHubActionsReporter {
     }
 
     async reportFatalError(error) {
-        core.setFailed(error.message);
+        // Anything can be thrown, not just an `Error`, so fall back to the
+        // thrown value itself rather than reporting nothing.
+        const message = error?.message || String(error);
+        const details = error?.stack || message;
+
+        core.setFailed(message);
         const summary = core.summary
             .addHeading('❗ Error', HEADING_LEVEL_2)
             .addRaw(
-                'An unexpected error occurred while checking for duplicate `msgid`s.',
+                'An unexpected error occurred while checking for duplicate <code>msgid</code>s.',
             )
-            .addCodeBlock(error.stack || error.message, 'javascript');
+            .addCodeBlock(escapeHtml(details), 'javascript');
         await addAttribution(summary).write();
     }
 


### PR DESCRIPTION
This started out stacked on #8. That has since merged, so this now targets `main` directly.

## The problem

The job summary text was written with Markdown backticks, but it never rendered as Markdown. `core.summary` emits HTML (`<h2>`, `<details>`, `<hr>`) with no blank lines between the pieces, so GitHub treats the whole summary as one contiguous HTML block — and Markdown is not processed inside an HTML block.

The result is visible in the screenshot in the README, and in the one attached to #5: readers get a literal `` `msgid` `` instead of `msgid`, and every file name is wrapped in stray backticks.

Before:

> ❌ **Found duplicate msgid's in 8 file(s)**
>
> The following files contain duplicate \`msgid\` entries. This can cause issues with translations. Please resolve them.
>
> ▸ \`/home/runner/work/lime-webclient/lime-webclient/lime_webclient/translations/da.po\` (1 duplicates)

After:

> ❌ **Found duplicate msgid's in 8 file(s)**
>
> The following files contain duplicate `msgid` entries. This can cause issues with translations. Please resolve them.
>
> ▸ `/home/runner/work/lime-webclient/lime-webclient/lime_webclient/translations/da.po` (1 duplicates)

## What changes

Every backtick in the summary text becomes a `<code>` element. The wording is untouched.

Anything interpolated into that markup is now escaped. File names and stack traces were being passed to `addDetails` and `addCodeBlock` raw — and `wrap()` in `@actions/core` does no escaping of its own, it is plain string interpolation. A `<` in either one emits a raw tag that swallows the rest of the summary. Node stack traces routinely contain `<anonymous>`, so this was not a theoretical concern:

```html
<pre lang="javascript"><code>Error: cannot read <config> at Object.<anonymous> (a.js:1)</code></pre>
```

## Review feedback addressed

Two nits from @anderssonjohan, both confirmed before changing anything:

- **Unescaped `addCodeBlock` in `reportFatalError`** — fixed here rather than deferred to a follow-up issue, since it is the same failure class as the file-name escaping already in this pull request. The error-message fallback used when no stack is available had the same problem and is now covered too.
- **The attribution tests asserted the footer was added, not that it was last** — a regression that moved the footer mid-summary would have passed. They now assert position as well. This was feedback on #8, which merged before it could be folded in, so it rides along here as a separate `test:` commit. Verified by moving the footer and watching the old assertion stay green and the new one fail.

## Verification

Running the built action against a file with duplicates and inspecting the written summary:

```html
<h2>❌ Found duplicate msgid's in 1 file(s)</h2>
The following files contain duplicate <code>msgid</code> entries. This can cause issues with translations. Please resolve them.<hr>
<details><summary><code>/tmp/smoke/sv.po</code> (1 duplicates)</summary><ul><li><pre><code>a</code></pre></li></ul></details>
<hr>
<sub>Reported by <a href="https://github.com/Lundalogik/po-linter">po-linter</a></sub>
```

And the fatal-error path with a stack trace containing `<`:

```html
<pre lang="javascript"><code>Error: cannot read &lt;config&gt; at Object.&lt;anonymous&gt; (a.js:1)</code></pre>
```

`npm run lint`, `npm test` (22 passing) and `npm run build` all pass, and the committed `dist/` matches a fresh build.

The README screenshots are now stale on several counts — the old `h1` success heading, no attribution footer, and the literal backticks. They are not updated here and need re-capturing by hand. This is tracked by #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
